### PR TITLE
fix: moved url validation to action for new posts

### DIFF
--- a/packages/frontpage/app/(app)/post/new/_action.ts
+++ b/packages/frontpage/app/(app)/post/new/_action.ts
@@ -12,7 +12,7 @@ export async function newPostAction(_prevState: unknown, formData: FormData) {
   "use server";
   const user = await ensureUser();
   const title = formData.get("title");
-  const url = formData.get("url");
+  let url = formData.get("url") as string;
 
   if (typeof title !== "string" || typeof url !== "string" || !title || !url) {
     return { error: "Provide a title and url." };
@@ -20,6 +20,13 @@ export async function newPostAction(_prevState: unknown, formData: FormData) {
 
   if (title.length > 120) {
     return { error: "Title too long" };
+  }
+
+  const allowedProtocols = ["http", "https", "at"];
+  const protocolRegex = new RegExp(`^(${allowedProtocols.join("|")}):\/\/`);
+
+  if (!protocolRegex.test(url)) {
+    url = `https://${url}`;
   }
 
   if (!URL.canParse(url)) {

--- a/packages/frontpage/app/(app)/post/new/_client.tsx
+++ b/packages/frontpage/app/(app)/post/new/_client.tsx
@@ -49,7 +49,6 @@ export function NewPostForm() {
         <Input
           name="url"
           id={`${id}-url`}
-          type="url"
           value={url}
           onChange={(e) => {
             setUrl(e.currentTarget.value);


### PR DESCRIPTION
This PR fixes UN-87 whereby if a user tries to enter a URL without a protocol, client validation would not allow the post to be submitted.

However, users should be able to submit posts with URLs such as `www.google.com` for example.

To do this, the type was removed off of the input and validation was added to the server action. I've tried to do it in a way that makes it easy to add / remove protocols but happy to take pointers on the implementation.