### PR TITLE
Improve create account script

### DIFF
--- a/packages/frontpage/local-infra/scripts/create-test-account.sh
+++ b/packages/frontpage/local-infra/scripts/create-test-account.sh
@@ -58,5 +58,6 @@ echo "Handle   : ${USERNAME}.pds.dev.unravel.fyi"
 echo "DID      : ${DID}"
 echo "Password : ${PASSWORD}"
 echo "-----------------------------"
-echo "Save this password, it will not be displayed again."
+echo "This is a test account with an insecure password."
+echo "Make sure it's only used for development."
 echo

--- a/packages/frontpage/local-infra/scripts/create-test-account.sh
+++ b/packages/frontpage/local-infra/scripts/create-test-account.sh
@@ -54,7 +54,7 @@ fi
 echo
 echo "Account created successfully!"
 echo "-----------------------------"
-echo "Handle   : ${USERNAME}.pds.dev.unravel.fyi"
+echo "Handle   : ${USERNAME}.${PDS_HOSTNAME}"
 echo "DID      : ${DID}"
 echo "Password : ${PASSWORD}"
 echo "-----------------------------"

--- a/packages/frontpage/local-infra/scripts/create-test-account.sh
+++ b/packages/frontpage/local-infra/scripts/create-test-account.sh
@@ -39,7 +39,7 @@ INVITE_CODE="$(curl_cmd_post \
   "https://${PDS_HOSTNAME}/xrpc/com.atproto.server.createInviteCode" | jq --raw-output '.code'
 )"
 RESULT="$(curl_cmd_post_nofail \
-  --data "{\"email\":\"${USERNAME}@pds.dev.unravel.fyi\", \"handle\":\"${USERNAME}.pds.dev.unravel.fyi\", \"password\":\"${PASSWORD}\", \"inviteCode\":\"${INVITE_CODE}\"}" \
+  --data "{\"email\":\"${USERNAME}@${PDS_HOSTNAME}\", \"handle\":\"${USERNAME}.${PDS_HOSTNAME}\", \"password\":\"${PASSWORD}\", \"inviteCode\":\"${INVITE_CODE}\"}" \
   "https://${PDS_HOSTNAME}/xrpc/com.atproto.server.createAccount"
 )"
 

--- a/packages/frontpage/local-infra/scripts/create-test-account.sh
+++ b/packages/frontpage/local-infra/scripts/create-test-account.sh
@@ -20,30 +20,26 @@ function curl_cmd_post_nofail {
   curl --silent --show-error --request POST --header "Content-Type: application/json" "$@"
 }
 
-EMAIL="${1:-}"
-HANDLE="${2:-}"
+USERNAME="${1:-}"
 
-if [[ "${EMAIL}" == "" ]]; then
-  read -p "Enter an email address (e.g. alice@${PDS_HOSTNAME}): " EMAIL
-fi
-if [[ "${HANDLE}" == "" ]]; then
-  read -p "Enter a handle (e.g. alice.${PDS_HOSTNAME}): " HANDLE
+if [[ "${USERNAME}" == "" ]]; then
+  read -p "Enter a username: " USERNAME
 fi
 
-if [[ "${EMAIL}" == "" || "${HANDLE}" == "" ]]; then
-  echo "ERROR: missing EMAIL and/or HANDLE parameters." >/dev/stderr
-  echo "Usage: $0 ${SUBCOMMAND} <EMAIL> <HANDLE>" >/dev/stderr
+if [[ "${USERNAME}" == "" ]]; then
+  echo "ERROR: missing USERNAME parameter." >/dev/stderr
+  echo "Usage: $0 ${SUBCOMMAND} <USERNAME>" >/dev/stderr
   exit 1
 fi
 
-PASSWORD="$(openssl rand -base64 30 | tr -d "=+/" | cut -c1-24)"
+PASSWORD="password"
 INVITE_CODE="$(curl_cmd_post \
   --user "admin:${PDS_ADMIN_PASSWORD}" \
   --data '{"useCount": 1}' \
   "https://${PDS_HOSTNAME}/xrpc/com.atproto.server.createInviteCode" | jq --raw-output '.code'
 )"
 RESULT="$(curl_cmd_post_nofail \
-  --data "{\"email\":\"${EMAIL}\", \"handle\":\"${HANDLE}\", \"password\":\"${PASSWORD}\", \"inviteCode\":\"${INVITE_CODE}\"}" \
+  --data "{\"email\":\"${USERNAME}@pds.dev.unravel.fyi\", \"handle\":\"${USERNAME}.pds.dev.unravel.fyi\", \"password\":\"${PASSWORD}\", \"inviteCode\":\"${INVITE_CODE}\"}" \
   "https://${PDS_HOSTNAME}/xrpc/com.atproto.server.createAccount"
 )"
 
@@ -58,7 +54,7 @@ fi
 echo
 echo "Account created successfully!"
 echo "-----------------------------"
-echo "Handle   : ${HANDLE}"
+echo "Handle   : ${USERNAME}.pds.dev.unravel.fyi"
 echo "DID      : ${DID}"
 echo "Password : ${PASSWORD}"
 echo "-----------------------------"


### PR DESCRIPTION
- Simplify arguments so that you only pass a username, we infer the handle and email from this using the hostname (pds.dev.unravel.fyi)
- Hardcode password as "password"
- Rename script to create-test-account and change output to emphasise this is a test account