### PR TITLE
fix: added pb for mobile and renamed branding

### DIFF
--- a/packages/frontpage/app/(app)/layout.tsx
+++ b/packages/frontpage/app/(app)/layout.tsx
@@ -30,7 +30,7 @@ export default async function Layout({
 }) {
   const session = await getSession();
   return (
-    <div className="container mx-auto px-4 md:px-6 pt-4 md:py-12 max-w-3xl">
+    <div className="container mx-auto px-4 md:px-6 pt-4 pb-8 md:py-12 max-w-3xl">
       <div className="flex place-content-between items-center mb-8">
         <Link href="/">
           {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -59,7 +59,7 @@ export default async function Layout({
             href={`https://bsky.app/profile/${FRONTPAGE_ATPROTO_HANDLE}`}
             className="font-medium text-indigo-600 hover:text-indigo-500 dark:text-indigo-400 dark:hover:text-indigo-300"
           >
-            @unravel.fyi <OpenInNewWindowIcon className="inline" />
+            @frontpage.fyi <OpenInNewWindowIcon className="inline" />
           </a>
         </p>
       </footer>


### PR DESCRIPTION
On iOS (Android users please check [link](https://frontpage.fyi/post/damien.frontpage.team/3l7bqu4nuzu2y)) the branding in the footer was not being displayed correctly. This pull request fixes that and it also changes the branding from unravel to frontpage.

Before:

![image](https://github.com/user-attachments/assets/c4cddcba-b622-45f8-932b-e51244107cc3)

After:

![image](https://github.com/user-attachments/assets/1b1dd010-a46b-4f88-aa60-909cdff718a3)