### PR TITLE
Add AT URIs as alternate links

### DIFF
--- a/packages/atproto-browser/app/at/[identifier]/[collection]/[rkey]/page.tsx
+++ b/packages/atproto-browser/app/at/[identifier]/[collection]/[rkey]/page.tsx
@@ -52,6 +52,10 @@ export default async function RkeyPage({
 
   return (
     <>
+      <link
+        rel="alternate"
+        href={`at://${params.identifier}/${params.collection}/${params.rkey}`}
+      />
       <h2>
         Record
         <Suspense

--- a/packages/atproto-browser/app/at/[identifier]/[collection]/page.tsx
+++ b/packages/atproto-browser/app/at/[identifier]/[collection]/page.tsx
@@ -25,6 +25,10 @@ export default async function CollectionPage({
 
   return (
     <div>
+      <link
+        rel="alternate"
+        href={`at://${params.identifier}/${params.collection}`}
+      />
       <h1>
         {params.collection} records{" "}
         <Link

--- a/packages/atproto-browser/app/at/[identifier]/page.tsx
+++ b/packages/atproto-browser/app/at/[identifier]/page.tsx
@@ -28,6 +28,7 @@ export default async function IdentifierPage({
 
   return (
     <>
+      <link rel="alternate" href={`at://${params.identifier}`} />
       <h1>
         <DidHandle did={identityResult.didDocument.id} />
       </h1>

--- a/packages/frontpage/app/(app)/post/[postAuthor]/[postRkey]/[commentAuthor]/[commentRkey]/page.tsx
+++ b/packages/frontpage/app/(app)/post/[postAuthor]/[postRkey]/[commentAuthor]/[commentRkey]/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { Metadata } from "next";
 import { getVerifiedHandle } from "@/lib/data/atproto/identity";
 import { CommentPageParams, getCommentPageData } from "./_lib/page-data";
+import { LinkAlternateAtUri } from "@/lib/components/link-alternate-at";
+import { CommentCollection } from "@/lib/data/atproto/comment";
 
 function truncateText(text: string, maxLength: number) {
   if (text.length > maxLength) {
@@ -57,6 +59,11 @@ export default async function CommentPage(props: {
 
   return (
     <>
+      <LinkAlternateAtUri
+        authority={comment.authorDid}
+        collection={CommentCollection}
+        rkey={comment.rkey}
+      />
       <div className="flex justify-end">
         <Link
           href={`/post/${params.postAuthor}/${params.postRkey}`}

--- a/packages/frontpage/app/(app)/post/[postAuthor]/[postRkey]/page.tsx
+++ b/packages/frontpage/app/(app)/post/[postAuthor]/[postRkey]/page.tsx
@@ -5,6 +5,8 @@ import { getCommentsForPost } from "@/lib/data/db/comment";
 import { Metadata } from "next";
 import { getVerifiedHandle } from "@/lib/data/atproto/identity";
 import { PostPageParams, getPostPageData } from "./_lib/page-data";
+import { LinkAlternateAtUri } from "@/lib/components/link-alternate-at";
+import { PostCollection } from "@/lib/data/atproto/post";
 
 export async function generateMetadata(props: {
   params: Promise<PostPageParams>;
@@ -44,6 +46,11 @@ export default async function Post(props: { params: Promise<PostPageParams> }) {
 
   return (
     <>
+      <LinkAlternateAtUri
+        authority={authorDid}
+        collection={PostCollection}
+        rkey={post.rkey}
+      />
       {post.status === "live" ? (
         <NewComment postRkey={post.rkey} postAuthorDid={authorDid} />
       ) : (

--- a/packages/frontpage/app/(app)/profile/[user]/page.tsx
+++ b/packages/frontpage/app/(app)/profile/[user]/page.tsx
@@ -22,6 +22,7 @@ import { EllipsisDropdown } from "../../_components/ellipsis-dropdown";
 import { ReportDialogDropdownButton } from "../../_components/report-dialog";
 import { reportUserAction } from "@/lib/components/user-hover-card";
 import { Metadata } from "next";
+import { LinkAlternateAtUri } from "@/lib/components/link-alternate-at";
 
 type Params = {
   user: string;
@@ -78,6 +79,7 @@ export default async function Profile(props: { params: Promise<Params> }) {
 
   return (
     <>
+      <LinkAlternateAtUri authority={did} />
       <div className="flex items-center space-x-4 mb-4">
         <UserAvatar did={did} size="medium" />
         <div className="flex flex-wrap items-center gap-2">

--- a/packages/frontpage/lib/components/link-alternate-at.tsx
+++ b/packages/frontpage/lib/components/link-alternate-at.tsx
@@ -1,0 +1,16 @@
+export function LinkAlternateAtUri({
+  authority,
+  collection,
+  rkey,
+}: {
+  authority: string;
+  collection?: string;
+  rkey?: string;
+}) {
+  return (
+    <link
+      rel="alternate"
+      href={`at://${[authority, collection, rkey].filter(Boolean).join("/")}`}
+    />
+  );
+}

--- a/packages/unravel/app/blog/[slug]/page.tsx
+++ b/packages/unravel/app/blog/[slug]/page.tsx
@@ -14,6 +14,10 @@ export default async function BlogPost({ params: { slug } }: Props) {
 
   return (
     <>
+      <link
+        rel="alternate"
+        href={`at://${blog.uri.authority}/${blog.uri.collection}/${blog.uri.rkey}`}
+      />
       <title>{blog.value.title}</title>
       <link rel="canonical" href={`/blog/${blog.slug}`} />
       <h1 className="text-4xl mb-8 mt-32">{blog.value.title}</h1>

--- a/packages/unravel/app/blog/blog-data.ts
+++ b/packages/unravel/app/blog/blog-data.ts
@@ -1,6 +1,10 @@
 import slugify from "slugify";
 import { z } from "zod";
 
+const FRONTPAGE_PDS_URL = "https://hydnum.us-west.host.bsky.network/xrpc";
+export const FRONTPAGE_DID = "did:plc:klmr76mpewpv7rtm3xgpzd7x";
+export const WHTWND_BLOG_COLLECTION = "com.whtwnd.blog.entry";
+
 // TODO: Extract into shared lib (it currently also exists in frontpage)
 const AtUri = z.string().transform((value, ctx) => {
   const match = value.match(/^at:\/\/(.+?)(\/.+?)?(\/.+?)?$/);
@@ -44,18 +48,15 @@ const BlogArray = z.object({
 });
 
 // Functions
-const serviceUri = "https://hydnum.us-west.host.bsky.network/xrpc";
-const repo = "did:plc:klmr76mpewpv7rtm3xgpzd7x";
-const collection = "com.whtwnd.blog.entry";
 
 export async function listBlogs() {
   const queryParams = new URLSearchParams({
-    repo: repo,
-    collection: collection,
+    repo: FRONTPAGE_DID,
+    collection: WHTWND_BLOG_COLLECTION,
   });
 
   const blogList = await fetch(
-    `${serviceUri}/com.atproto.repo.listRecords?${queryParams}`,
+    `${FRONTPAGE_PDS_URL}/com.atproto.repo.listRecords?${queryParams}`,
     {
       method: "GET",
       headers: {
@@ -73,13 +74,13 @@ export async function listBlogs() {
 
 export async function getBlog(rkey: string) {
   const queryParams = new URLSearchParams({
-    repo: repo,
-    collection: collection,
+    repo: FRONTPAGE_DID,
+    collection: WHTWND_BLOG_COLLECTION,
     rkey: rkey,
   });
 
   const response = await fetch(
-    `${serviceUri}/com.atproto.repo.getRecord?${queryParams}`,
+    `${FRONTPAGE_PDS_URL}/com.atproto.repo.getRecord?${queryParams}`,
     {
       method: "GET",
       headers: {

--- a/packages/unravel/app/blog/page.tsx
+++ b/packages/unravel/app/blog/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { listBlogs } from "./blog-data";
+import { FRONTPAGE_DID, listBlogs, WHTWND_BLOG_COLLECTION } from "./blog-data";
 
 const dateFormatter = new Intl.DateTimeFormat("en-US", {
   dateStyle: "medium",
@@ -9,6 +9,10 @@ export default async function Blog() {
   const blogList = await listBlogs();
   return (
     <>
+      <link
+        rel="alternate"
+        href={`at://${FRONTPAGE_DID}/${WHTWND_BLOG_COLLECTION}`}
+      />
       <h1 className="text-4xl mb-8">Unravel Blog</h1>
       <ul className="flex flex-col space-y-6">
         {blogList.records.map((blog) => (


### PR DESCRIPTION
I'm trying to start a convention that allows tooling (eg. crawlers, browsers, extensions) to link the web representation of a record to it's canonical `at://` URI. I see no better way to try this than to start doing it in frontpage and atproto browser.

There are multiple representations of the same URI on atproto, due to the authority section being either a handle or a DID. My recommendation is to prefer the DID-based representation, but including the handle is valid also.

> [!IMPORTANT]
> The convention I've landed on is `<link rel="alternate" href="<AT URI>">`. Note: no `type` attribute because specifying one doesn't really make sense, it's up to whatever tooling that is consuming these URIs to decide how to fetch the record.

In the future we can potentially pickup on these URIs when submitting links to Frontpage to maintain a reference to the record on the protocol.

Some examples of the links in this PR:

- Frontpage profile eg. https://frontpage.fyi/profile/tom.frontpage.team -> `at://did:plc:2xau7wbgdq4phuou2ypwuen7`
- Frontpage post eg. https://frontpage.fyi/post/tom.frontpage.team/3l7dwhqjru623 -> `at://did:plc:2xau7wbgdq4phuou2ypwuen7/fyi.unravel.frontpage.post/3l7dwhqjru623`
- Frontpage comment eg. https://frontpage.fyi/post/damien.frontpage.team/3l7bqu4nuzu2y/tom.frontpage.team/3l7bzyhx3ry2r -> `at://did:plc:2xau7wbgdq4phuou2ypwuen7/fyi.unravel.frontpage.comment/3l7bzyhx3ry2r`
- Atproto browser profile eg. https://atproto-browser.vercel.app/at/tom.frontpage.team -> `at://tom.frontpage.team`
- Atproto browser bluesky post eg. https://atproto-browser.vercel.app/at/did:plc:2xau7wbgdq4phuou2ypwuen7/app.bsky.feed.post/3l7emhqdj6f2s -> `at://did:plc:2xau7wbgdq4phuou2ypwuen7/app.bsky.feed.post/3l7emhqdj6f2s`

Note, the mapping is slightly different between the two apps. For Frontpage I've chosen to always show a DID but on atproto-browser I've preserved the handle where relevant because it matches the intent of the application.