### PR TITLE
fix: adds a bg-accent to selected theme choice

### DIFF
--- a/packages/frontpage/app/(app)/_components/theme-toggle.tsx
+++ b/packages/frontpage/app/(app)/_components/theme-toggle.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/lib/components/ui/dropdown-menu";
 
 export function ThemeToggle() {
-  const { setTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
 
   return (
     <DropdownMenu>
@@ -24,14 +24,23 @@ export function ThemeToggle() {
           <span className="sr-only">Toggle theme</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onClick={() => setTheme("light")}>
+      <DropdownMenuContent className="space-y-0.5" align="end">
+        <DropdownMenuItem
+          className={`${theme === "light" ? "bg-accent" : ""}`}
+          onClick={() => setTheme("light")}
+        >
           Light
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("dark")}>
+        <DropdownMenuItem
+          className={`${theme === "dark" ? "bg-accent" : ""}`}
+          onClick={() => setTheme("dark")}
+        >
           Dark
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme("system")}>
+        <DropdownMenuItem
+          className={`${theme === "system" ? "bg-accent" : ""}`}
+          onClick={() => setTheme("system")}
+        >
           System
         </DropdownMenuItem>
       </DropdownMenuContent>


### PR DESCRIPTION
I noticed that the theme-toggle does not show you which theme you are currently using so this pr addresses that. I also added a tiny bit of spacing so when hovering on a theme choice, it does not collide with the chosen theme if choosing one next to the current choice.

![Screenshot from 2024-10-27 00-39-28](https://github.com/user-attachments/assets/58b357a6-a145-4833-b57c-64f36b1902fc)

![Screenshot from 2024-10-27 00-40-17](https://github.com/user-attachments/assets/068d4ed0-aade-49c1-a728-bbf246943215)

![Screenshot from 2024-10-27 00-39-55](https://github.com/user-attachments/assets/90b28d6f-8ee4-4d7e-a7e9-efd6d7f8e36c)

![Screenshot from 2024-10-27 00-40-08](https://github.com/user-attachments/assets/97c7bd85-e88c-46c3-9ad3-9d66be302fd1)
