### PR TITLE
fix: correct url search param type to be a string

### DIFF
--- a/packages/atproto-browser/app/at/_lib/collection.tsx
+++ b/packages/atproto-browser/app/at/_lib/collection.tsx
@@ -51,7 +51,9 @@ export function CollectionItems({
             fetchKey={`listCollections/collection:${collection}/cursor:${data.cursor!}`}
           />
         </Suspense>
-      ) : data.cursor !== "self" && data.records.length > 0 && data.records.length == FETCH_LIMIT ? (
+      ) : data.cursor !== "self" &&
+        data.records.length > 0 &&
+        data.records.length == Number(FETCH_LIMIT) ? (
         <button type="button" onClick={() => setMore(true)}>
           Load more
         </button>

--- a/packages/atproto-browser/app/consts.tsx
+++ b/packages/atproto-browser/app/consts.tsx
@@ -1,2 +1,2 @@
-export const FETCH_LIMIT = 100;
+export const FETCH_LIMIT = "100";
 export const EXAMPLE_PATH = "tom-sherman.com/app.bsky.feed.like/3kyutnrmg3s2r";

--- a/packages/atproto-browser/app/consts.tsx
+++ b/packages/atproto-browser/app/consts.tsx
@@ -1,2 +1,3 @@
+// Set as a string as it is primarily used as a query parameter, cast to number when needed
 export const FETCH_LIMIT = "100";
 export const EXAMPLE_PATH = "tom-sherman.com/app.bsky.feed.like/3kyutnrmg3s2r";


### PR DESCRIPTION
This pr originally fixed an issue where a number was being used as a search param value when it expected a string. Which in turn broke somewhere else where we needed a number.

So the const is now a string and it is cast to a number where we need a number for a length check.