### PR TITLE
fix : title does not break

### DIFF
--- a/packages/frontpage/app/(app)/_components/post-card.tsx
+++ b/packages/frontpage/app/(app)/_components/post-card.tsx
@@ -83,7 +83,7 @@ export async function PostCard({
           votes={votes}
         />
       </div>
-      <div className="w-full">
+      <div className="w-full overflow-hidden">
         <h2 className="mb-1 text-xl">
           <a
             href={url}


### PR DESCRIPTION
This temporarily avoids the issue of h2 not wrapping.

It seems that this cannot be avoided using `break-words` etc.

```html
<h2 class="break-all whitespace-pre-wrap">
 0123456789012345678901234567890123456789012345678901234567890123456789
</h2>
```

![スクリーンショット 2024-10-30 4 53 31](https://github.com/user-attachments/assets/47648218-4a84-458b-9e7e-1743be18db2e)
