### PR TITLE
Post options cursor pointer

### DIFF
--- a/packages/frontpage/app/(app)/_components/theme-toggle.tsx
+++ b/packages/frontpage/app/(app)/_components/theme-toggle.tsx
@@ -18,15 +18,24 @@ export function ThemeToggleMenuGroup() {
       <DropdownMenuLabel className="truncate">Theme</DropdownMenuLabel>
       <DropdownMenuSeparator />
       <DropdownMenuRadioGroup value={theme} onValueChange={setTheme}>
-        <DropdownMenuRadioItem value="light" className="flex gap-1.5">
+        <DropdownMenuRadioItem
+          value="light"
+          className="flex gap-1.5 cursor-pointer"
+        >
           <SunIcon className="size-4" />
           <span>Light</span>
         </DropdownMenuRadioItem>
-        <DropdownMenuRadioItem value="dark" className="flex gap-1.5">
+        <DropdownMenuRadioItem
+          value="dark"
+          className="flex gap-1.5 cursor-pointer"
+        >
           <MoonIcon className="h-[1.2rem] w-[1.2rem]" />
           <span>Dark</span>
         </DropdownMenuRadioItem>
-        <DropdownMenuRadioItem value="system" className="flex gap-1.5">
+        <DropdownMenuRadioItem
+          value="system"
+          className="flex gap-1.5 cursor-pointer"
+        >
           <Half2Icon className="h-[1.2rem] w-[1.2rem]" />
           <span>System</span>
         </DropdownMenuRadioItem>

--- a/packages/frontpage/app/(app)/_components/theme-toggle.tsx
+++ b/packages/frontpage/app/(app)/_components/theme-toggle.tsx
@@ -18,24 +18,15 @@ export function ThemeToggleMenuGroup() {
       <DropdownMenuLabel className="truncate">Theme</DropdownMenuLabel>
       <DropdownMenuSeparator />
       <DropdownMenuRadioGroup value={theme} onValueChange={setTheme}>
-        <DropdownMenuRadioItem
-          value="light"
-          className="flex gap-1.5 cursor-pointer"
-        >
+        <DropdownMenuRadioItem value="light" className="flex gap-1.5">
           <SunIcon className="size-4" />
           <span>Light</span>
         </DropdownMenuRadioItem>
-        <DropdownMenuRadioItem
-          value="dark"
-          className="flex gap-1.5 cursor-pointer"
-        >
+        <DropdownMenuRadioItem value="dark" className="flex gap-1.5">
           <MoonIcon className="h-[1.2rem] w-[1.2rem]" />
           <span>Dark</span>
         </DropdownMenuRadioItem>
-        <DropdownMenuRadioItem
-          value="system"
-          className="flex gap-1.5 cursor-pointer"
-        >
+        <DropdownMenuRadioItem value="system" className="flex gap-1.5">
           <Half2Icon className="h-[1.2rem] w-[1.2rem]" />
           <span>System</span>
         </DropdownMenuRadioItem>

--- a/packages/frontpage/lib/components/ui/dropdown-menu.tsx
+++ b/packages/frontpage/lib/components/ui/dropdown-menu.tsx
@@ -95,7 +95,7 @@ function DropdownMenuItem({
   return (
     <DropdownMenuPrimitive.Item
       className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         inset && "pl-8",
         className,
       )}

--- a/packages/frontpage/lib/components/ui/dropdown-menu.tsx
+++ b/packages/frontpage/lib/components/ui/dropdown-menu.tsx
@@ -140,7 +140,7 @@ function DropdownMenuRadioItem({
   return (
     <DropdownMenuPrimitive.RadioItem
       className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "relative flex cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         className,
       )}
       {...props}


### PR DESCRIPTION
# Description

Added `cursor-pointer` to `DropdownMenuPrimitive.Item` so that the attached buttons use the same cursor as the user dropdown items
![image](https://github.com/user-attachments/assets/fdfaee59-460f-4b9c-ac52-910ce0d6c025)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
