### PR TITLE
Smaller avatar images

### DIFF
--- a/packages/frontpage/lib/components/user-avatar.tsx
+++ b/packages/frontpage/lib/components/user-avatar.tsx
@@ -53,7 +53,11 @@ async function AvatarImage({
   return (
     // eslint-disable-next-line @next/next/no-img-element
     <img
-      src={profile.avatar}
+      src={
+        sizeVariant === "large"
+          ? profile.avatar
+          : profile.avatar.replace("/avatar/", "/avatar_thumbnail/")
+      }
       alt=""
       width={size}
       height={size}


### PR DESCRIPTION
Use the smaller thumbnail images where appropriate to improve speeds and reduce bandwidth.