### PR TITLE
BREAKING: Stable frontpage lexicon

### DIFF
--- a/lexicons/fyi/frontpage/feed/comment.json
+++ b/lexicons/fyi/frontpage/feed/comment.json
@@ -1,0 +1,27 @@
+{
+  "lexicon": 1,
+  "id": "fyi.unravel.frontpage.comment",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record containing a Frontpage comment.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["createdAt", "post"],
+        "properties": {
+          "content": {
+            // TODO: richtext
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this comment was originally created."
+          },
+          "parent": { "type": "ref", "ref": "com.atproto.repo.strongRef" },
+          "post": { "type": "ref", "ref": "com.atproto.repo.strongRef" }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/fyi/frontpage/feed/comment.json
+++ b/lexicons/fyi/frontpage/feed/comment.json
@@ -8,10 +8,14 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["createdAt", "post"],
+        "required": ["createdAt", "post", "blocks"],
         "properties": {
-          "content": {
-            // TODO: richtext
+          "blocks": {
+            "type": "array",
+            "items": {
+              "type": "ref",
+              "ref": "fyi.unravel.frontpage.richtext.block"
+            }
           },
           "createdAt": {
             "type": "string",

--- a/lexicons/fyi/frontpage/feed/post.json
+++ b/lexicons/fyi/frontpage/feed/post.json
@@ -1,0 +1,33 @@
+{
+  "lexicon": 1,
+  "id": "fyi.unravel.frontpage.post",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record containing a Frontpage post.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["title", "createdAt"],
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 3000,
+            "maxGraphemes": 300,
+            "description": "The title of the post."
+          },
+          "subject": {
+            "type": "union",
+            "description": "The piece of content that this Frontpage post is about.",
+            "refs": ["fyi.frontpage.subject.url"]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this post was originally created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/fyi/frontpage/feed/vote.json
+++ b/lexicons/fyi/frontpage/feed/vote.json
@@ -1,0 +1,23 @@
+{
+  "lexicon": 1,
+  "id": "fyi.unravel.frontpage.vote",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Record containing a Frontpage vote.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["subject", "createdAt"],
+        "properties": {
+          "subject": { "type": "ref", "ref": "com.atproto.repo.strongRef" },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Client-declared timestamp when this vote was originally created."
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/fyi/frontpage/richtext/block.json
+++ b/lexicons/fyi/frontpage/richtext/block.json
@@ -1,0 +1,35 @@
+{
+  "lexicon": 1,
+  "id": "fyi.unravel.frontpage.richtext.block",
+  "defs": {
+    "main": {
+      "type": "union",
+      "refs": ["#paragraph"]
+    },
+    "paragraph": {
+      "type": "object",
+      "properties": {
+        "content": { "type": "ref", "ref": "#richtext" }
+      }
+    },
+    "richtext": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["text"],
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "facets": {
+            "type": "array",
+            "items": {
+              "type": "ref",
+              "ref": "fyi.frontpage.richtext.facet"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/fyi/frontpage/richtext/facet.json
+++ b/lexicons/fyi/frontpage/richtext/facet.json
@@ -1,0 +1,10 @@
+{
+  "lexicon": 1,
+  "id": "app.bsky.richtext.facet",
+  "defs": {
+    "main": {
+      "type": "union",
+      "refs": []
+    }
+  }
+}

--- a/lexicons/fyi/frontpage/subject/url.json
+++ b/lexicons/fyi/frontpage/subject/url.json
@@ -1,0 +1,17 @@
+{
+  "lexicon": 1,
+  "id": "fyi.frontpage.subject.url",
+  "description": "A link to a webpage URL.",
+  "defs": {
+    "main": {
+      "type": "object",
+      "required": ["url"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Goals:

- Make room for different post types (future)
- Allow for richtext comments with embeds (future)
- Move the lexicon to the `fyi.frontpage` namespace

## Changes

### Post "subjects"

To allow for different post types in the future (eg. longform text, media, polls) we add a `subject` field to post. This is an open union with currently one defined value: a URL. The open union allows for non-breaking extension later.

### Richtext comments

Comments are now made up of an array of blocks. For now a block can simply be a paragraph, but in the future could be an image, codeblock, etc.

The paragraph holds the richtext content which is a type heavily inspired https://github.com/bluesky-social/atproto/discussions/2830

### `fyi.frontpage` namespace

Moves to the stable fyi.frontpage NSID. It's a good time to do this because the above changes are backwards incompatible (breaking).

## Rollout

- Gather and implement any feedback
- Merge PR and publish lexicons to atproto using [lexicon resolution](https://atproto.com/specs/lexicon#lexicon-publication-and-resolution)
- Implement support for ingesting new lexicon in Frontpage AppView for testing
- 4 weeks after merging/publishing (TBC: is this long enough?) start creating records with the new lexicon