### PR TITLE
Use timing attack safe comparisons when checking auth headers

### DIFF
--- a/packages/frontpage/app/api/cron/oauth-cleanup/route.ts
+++ b/packages/frontpage/app/api/cron/oauth-cleanup/route.ts
@@ -3,10 +3,16 @@ import { sendDiscordMessage } from "@/lib/discord";
 import type { NextRequest } from "next/server";
 import * as schema from "@/lib/schema";
 import { lt, inArray } from "drizzle-orm";
+import { timingSafeEqual } from "node:crypto";
+
+const EXPECTED_AUTH_HEADER = Buffer.from(`Bearer ${process.env.CRON_SECRET}`);
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (
+    !authHeader ||
+    !timingSafeEqual(Buffer.from(authHeader), EXPECTED_AUTH_HEADER)
+  ) {
     await sendDiscordMessage({
       embeds: [
         {

--- a/packages/frontpage/app/api/cron/rank-posts/route.ts
+++ b/packages/frontpage/app/api/cron/rank-posts/route.ts
@@ -2,10 +2,16 @@ import { db } from "@/lib/db";
 import { sendDiscordMessage } from "@/lib/discord";
 import type { NextRequest } from "next/server";
 import { updateAllPostRanks } from "@/lib/data/db/triggers";
+import { timingSafeEqual } from "node:crypto";
+
+const EXPECTED_AUTH_HEADER = Buffer.from(`Bearer ${process.env.CRON_SECRET}`);
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (
+    !authHeader ||
+    !timingSafeEqual(Buffer.from(authHeader), EXPECTED_AUTH_HEADER)
+  ) {
     await sendDiscordMessage({
       embeds: [
         {


### PR DESCRIPTION
The only places that need to change are in the private APIs (crons and drainpipe receive hook). User auth isn't affected because it uses jwtVerify which is already resilient to timing attacks.