### PR TITLE
PDS-based login

### DIFF
--- a/packages/frontpage/app/(auth)/login/_lib/action.tsx
+++ b/packages/frontpage/app/(auth)/login/_lib/action.tsx
@@ -2,7 +2,10 @@
 import { signIn } from "@/lib/auth-sign-in";
 import { isValidHandle } from "@atproto/syntax";
 
-export async function loginAction(_prevStart: unknown, formData: FormData) {
+export async function loginWithIdentifierAction(
+  _prevStart: unknown,
+  formData: FormData,
+) {
   const identifier = formData.get("identifier") as string;
   let handleOrDid = identifier.trim();
   // Sanitize only handles
@@ -12,7 +15,40 @@ export async function loginAction(_prevStart: unknown, formData: FormData) {
   ) {
     handleOrDid = identifier.replace(/^@/, "").toLowerCase();
   }
-  const result = await signIn(handleOrDid);
+  const result = await signIn({ identifier: handleOrDid });
+  if (result && "error" in result) {
+    return {
+      error: `An error occured while signing in (${result.error})`,
+    };
+  }
+}
+
+export async function loginWithPdsAction(
+  _prevStart: unknown,
+  formData: FormData,
+) {
+  const pdsUrl = formData.get("pdsUrl");
+  if (typeof pdsUrl !== "string") {
+    return {
+      error: "Please enter a PDS URL",
+    };
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(
+      pdsUrl.startsWith("http") ? pdsUrl : `https://${pdsUrl}`,
+    );
+  } catch (_) {
+    return {
+      error: "Invalid URL",
+    };
+  }
+
+  const result = await signIn({
+    pdsUrl: parsedUrl,
+  });
+
   if (result && "error" in result) {
     return {
       error: `An error occured while signing in (${result.error})`,

--- a/packages/frontpage/app/(auth)/login/_lib/form.tsx
+++ b/packages/frontpage/app/(auth)/login/_lib/form.tsx
@@ -10,6 +10,7 @@ import { CrossCircledIcon } from "@radix-ui/react-icons";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -47,6 +48,9 @@ export function LoginForm() {
             <DialogContent>
               <DialogHeader>
                 <DialogTitle>Login with another PDS</DialogTitle>
+                <DialogDescription>
+                  Enter the URL of your PDS to login.
+                </DialogDescription>
               </DialogHeader>
 
               <PdsForm />
@@ -63,6 +67,9 @@ export function LoginForm() {
             <DialogContent>
               <DialogHeader>
                 <DialogTitle>Login with handle</DialogTitle>
+                <DialogDescription>
+                  Enter your Bluesky/AT Protocol handle to login.
+                </DialogDescription>
               </DialogHeader>
 
               <IdentifierForm />
@@ -102,20 +109,16 @@ function IdentifierForm() {
         });
       }}
     >
-      <div>
-        <Label htmlFor="handle">Handle</Label>
-        <Input
-          id="identifier"
-          name="identifier"
-          required
-          placeholder="example.com"
-        />
-      </div>
-      <div>
-        <Button type="submit" className="w-full" disabled={isIdentiferPending}>
-          Sign in
-        </Button>
-      </div>
+      <Input
+        id="identifier"
+        name="identifier"
+        required
+        placeholder="eg. dril.bsky.social"
+      />
+
+      <Button type="submit" className="w-full" disabled={isIdentiferPending}>
+        Login
+      </Button>
 
       <LoginError errorState={identifierState?.error} />
     </form>
@@ -129,7 +132,7 @@ function PdsForm() {
   );
   return (
     <form className="space-y-6" action={pdsAction}>
-      <Input name="pdsUrl" />
+      <Input name="pdsUrl" placeholder="eg. bsky.social" />
       <Button type="submit" className="w-full" disabled={isPdsPending}>
         Login
       </Button>

--- a/packages/frontpage/app/(auth)/login/_lib/form.tsx
+++ b/packages/frontpage/app/(auth)/login/_lib/form.tsx
@@ -1,60 +1,140 @@
 "use client";
 
-import { startTransition, Suspense, useActionState } from "react";
-import { loginAction } from "./action";
+import { startTransition, useActionState, useState } from "react";
+import { loginWithIdentifierAction, loginWithPdsAction } from "./action";
 import { Label } from "@/lib/components/ui/label";
 import { Input } from "@/lib/components/ui/input";
 import { Button } from "@/lib/components/ui/button";
-import { useSearchParams } from "next/navigation";
 import { Alert, AlertDescription, AlertTitle } from "@/lib/components/ui/alert";
 import { CrossCircledIcon } from "@radix-ui/react-icons";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/lib/components/ui/dialog";
 
 export function LoginForm() {
-  const [state, action, isPending] = useActionState(loginAction, null);
+  const [pdsDialogOpen, setPdsDialogOpen] = useState(false);
+  const [pdsState, pdsAction, isPdsPending] = useActionState(
+    loginWithPdsAction,
+    null,
+  );
 
   return (
     <>
-      <form
-        className="space-y-6"
-        action={action}
-        onSubmit={(event) => {
-          event.preventDefault();
-          startTransition(() => {
-            action(new FormData(event.currentTarget));
-          });
-        }}
-      >
-        <div>
-          <Label htmlFor="handle">Handle</Label>
-          <Input
-            id="identifier"
-            name="identifier"
-            required
-            placeholder="example.com"
-          />
-        </div>
-        <div>
-          <Button type="submit" className="w-full" disabled={isPending}>
-            Sign in
+      <div className="space-y-6">
+        <form className="contents" action={pdsAction}>
+          <Button
+            className="w-full"
+            type="submit"
+            name="pdsUrl"
+            value="bsky.social"
+            disabled={isPdsPending}
+          >
+            Login with bsky.social
           </Button>
+        </form>
+
+        <div className="flex gap-2">
+          <Dialog open={pdsDialogOpen} onOpenChange={setPdsDialogOpen}>
+            <DialogTrigger asChild>
+              <Button className="w-full" variant="outline">
+                Login with another PDS
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Login with another PDS</DialogTitle>
+              </DialogHeader>
+
+              <PdsForm />
+            </DialogContent>
+          </Dialog>
+
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button className="w-full" variant="outline">
+                Login with @handle
+              </Button>
+            </DialogTrigger>
+
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Login with handle</DialogTitle>
+              </DialogHeader>
+
+              <IdentifierForm />
+            </DialogContent>
+          </Dialog>
         </div>
-      </form>
-      <Suspense>
-        <LoginError errorState={state?.error} />
-      </Suspense>
+
+        <LoginError errorState={pdsState?.error} />
+      </div>
     </>
   );
 }
 
 function LoginError({ errorState }: { errorState?: string }) {
-  const searchParams = useSearchParams();
-  const error = errorState ?? searchParams.get("error");
-  if (!error) return null;
+  if (!errorState) return null;
   return (
     <Alert variant="destructive">
       <CrossCircledIcon className="h-4 w-4" />
       <AlertTitle>Login error</AlertTitle>
-      <AlertDescription>{error}</AlertDescription>
+      <AlertDescription>{errorState}</AlertDescription>
     </Alert>
+  );
+}
+
+function IdentifierForm() {
+  const [identifierState, identifierAction, isIdentiferPending] =
+    useActionState(loginWithIdentifierAction, null);
+
+  return (
+    <form
+      className="space-y-6"
+      action={identifierAction}
+      onSubmit={(event) => {
+        event.preventDefault();
+        startTransition(() => {
+          identifierAction(new FormData(event.currentTarget));
+        });
+      }}
+    >
+      <div>
+        <Label htmlFor="handle">Handle</Label>
+        <Input
+          id="identifier"
+          name="identifier"
+          required
+          placeholder="example.com"
+        />
+      </div>
+      <div>
+        <Button type="submit" className="w-full" disabled={isIdentiferPending}>
+          Sign in
+        </Button>
+      </div>
+
+      <LoginError errorState={identifierState?.error} />
+    </form>
+  );
+}
+
+function PdsForm() {
+  const [pdsState, pdsAction, isPdsPending] = useActionState(
+    loginWithPdsAction,
+    null,
+  );
+  return (
+    <form className="space-y-6" action={pdsAction}>
+      <Input name="pdsUrl" />
+      <Button type="submit" className="w-full" disabled={isPdsPending}>
+        Login
+      </Button>
+
+      <LoginError errorState={pdsState?.error} />
+    </form>
   );
 }

--- a/packages/frontpage/app/(auth)/login/page.tsx
+++ b/packages/frontpage/app/(auth)/login/page.tsx
@@ -1,13 +1,21 @@
 import { redirect } from "next/navigation";
 import { LoginForm } from "./_lib/form";
 import { getUser } from "@/lib/data/user";
+import { Alert, AlertDescription, AlertTitle } from "@/lib/components/ui/alert";
+import { CrossCircledIcon } from "@radix-ui/react-icons";
 
-export default async function LoginPage() {
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
   const user = await getUser();
 
   if (user !== null) {
     redirect("/");
   }
+
+  const error = (await searchParams).error;
 
   return (
     <div className="flex items-center justify-center min-h-screen px-4 sm:px-6 lg:px-8">
@@ -28,6 +36,13 @@ export default async function LoginPage() {
           </p>
         </div>
         <LoginForm />
+        {error ? (
+          <Alert variant="destructive">
+            <CrossCircledIcon className="h-4 w-4" />
+            <AlertTitle>Login error, please try again</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        ) : null}
       </div>
     </div>
   );

--- a/packages/frontpage/lib/auth-sign-in.ts
+++ b/packages/frontpage/lib/auth-sign-in.ts
@@ -19,33 +19,56 @@ import { db } from "./db";
 import * as schema from "./schema";
 import { redirect } from "next/navigation";
 
-export async function signIn(identifier: string) {
-  const did = await getDidFromHandleOrDid(identifier);
-  if (!did) {
+type SignInInput =
+  | {
+      identifier: string;
+    }
+  | {
+      pdsUrl: URL;
+    };
+
+export async function signIn(input: SignInInput) {
+  let authServerUrl: URL;
+  if ("identifier" in input) {
+    const did = await getDidFromHandleOrDid(input.identifier);
+    if (!did) {
+      return {
+        error: "DID_NOT_FOUND" as const,
+      };
+    }
+    const meta = await oauthProtectedMetadataRequest(did);
+    if ("error" in meta) {
+      return meta;
+    }
+    const server = meta.data.authorization_servers?.[0];
+    if (!server) {
+      return {
+        error: "NO_AUTH_SERVER" as const,
+      };
+    }
+
+    authServerUrl = new URL(server);
+  } else if ("pdsUrl" in input) {
+    authServerUrl = input.pdsUrl;
+  } else {
+    throw new Error("Invalid input");
+  }
+
+  let authServer;
+
+  try {
+    // TODO: Cache this
+    authServer = await processDiscoveryResponse(
+      authServerUrl,
+      await discoveryRequest(new URL(authServerUrl), {
+        algorithm: "oauth2",
+      }),
+    );
+  } catch (_) {
     return {
-      error: "DID_NOT_FOUND" as const,
+      error: "INVALID_AUTH_SERVER" as const,
     };
   }
-
-  const meta = await oauthProtectedMetadataRequest(did);
-  if ("error" in meta) {
-    return meta;
-  }
-
-  const authServerUrl = meta.data.authorization_servers?.[0];
-  if (!authServerUrl) {
-    return {
-      error: "NO_AUTH_SERVER" as const,
-    };
-  }
-
-  // TODO: Cache this
-  const authServer = await processDiscoveryResponse(
-    new URL(authServerUrl),
-    await discoveryRequest(new URL(authServerUrl), {
-      algorithm: "oauth2",
-    }),
-  );
 
   // Check this early, we'll need it later
   const authorizationEndpiont = authServer.authorization_endpoint;
@@ -77,7 +100,11 @@ export async function signIn(identifier: string) {
         state,
         redirect_uri: client.redirect_uris[0],
         scope: client.scope,
-        login_hint: identifier,
+        ...("identifier" in input
+          ? {
+              login_hint: input.identifier,
+            }
+          : {}),
       },
       {
         DPoP: {
@@ -141,9 +168,12 @@ export async function signIn(identifier: string) {
   }
 
   await db.insert(schema.OauthAuthRequest).values({
-    did: did,
+    did:
+      "identifier" in input
+        ? (await getDidFromHandleOrDid(input.identifier)) ?? ""
+        : "",
     iss: authServer.issuer,
-    username: identifier,
+    username: "identifier" in input ? input.identifier : "",
     nonce: dpopNonce,
     state,
     pkceVerifier,

--- a/packages/frontpage/lib/schema.ts
+++ b/packages/frontpage/lib/schema.ts
@@ -22,6 +22,12 @@ const did = customType<{ data: DID }>({
   },
 });
 
+const didOrEmptyString = customType<{ data: DID | "" }>({
+  dataType() {
+    return "text";
+  },
+});
+
 const nowAsIsoString = sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`;
 
 const dateIsoText = customType<{ data: Date; driverData: string }>({
@@ -197,7 +203,7 @@ export const ConsumedOffset = sqliteTable("consumed_offsets", {
 export const OauthAuthRequest = sqliteTable("oauth_auth_requests", {
   state: text("state").notNull().unique(),
   iss: text("iss").notNull(),
-  did: did("did").notNull(),
+  did: didOrEmptyString("did").notNull(),
   username: text("username").notNull(),
   nonce: text("nonce").notNull(),
   pkceVerifier: text("pkce_verifier").notNull(),


### PR DESCRIPTION
This change includes a new login method that allows the user to login using their PDS without typing their handle.

| Login screen | PDS dialog | Handle dialog |
|--------|--------|--------|
| <img width="620" alt="image" src="https://github.com/user-attachments/assets/80266a63-b073-47a3-a766-f00648a50131" /> | <img width="557" alt="image" src="https://github.com/user-attachments/assets/5cb4b09a-2b3c-4433-86d0-fb2cbe488779" /> | <img width="591" alt="image" src="https://github.com/user-attachments/assets/17cd7378-5fc4-4859-8411-bde08e81c29b" /> | 

Under the hood this is done via omitting the login hint when performing the PAR. This allows the user to login to any account on that PDS (usually without typing anything as they'll already be logged in).

The UI treats bsky.social login as the primary method as a pragmatic choice (most people are on a Bluesky PDS). I've gone back and forth on what this means for decentralisation or encouraging self hosting and I think the UX improvements vastly outweigh any theoretical decentralisation arguments.

Self hosters are able to login by typing their PDS host URL. I want to add autocomplete here from the list of known servers from the relay (`listHosts` endpoint) but that can be done in a followup PR.

The UX is improved but ultimately it's a trade off. Hopefully in the future something like FedCM can help us with automatically detecting which PDS/handle (or list of PDSes/handles) the user can login with.