### PR TITLE
Reapply: Improve middleware performance by reading expiry from cookie instead of database

### DIFF
--- a/packages/frontpage/app/(app)/layout.tsx
+++ b/packages/frontpage/app/(app)/layout.tsx
@@ -1,4 +1,4 @@
-import { deleteAuthCookie, getSession, signOut } from "@/lib/auth";
+import { getSession, signOut } from "@/lib/auth";
 import Link from "next/link";
 import { Suspense } from "react";
 import { Button } from "@/lib/components/ui/button";
@@ -20,7 +20,6 @@ import {
 } from "@/lib/components/ui/dropdown-menu";
 import { UserAvatar } from "@/lib/components/user-avatar";
 import { FRONTPAGE_ATPROTO_HANDLE } from "@/lib/constants";
-import { cookies } from "next/headers";
 import { revalidatePath } from "next/cache";
 import { NotificationIndicator } from "./_components/notification-indicator";
 import {
@@ -137,7 +136,6 @@ async function LoginOrLogout() {
               action={async () => {
                 "use server";
                 await signOut();
-                deleteAuthCookie(await cookies());
                 revalidatePath("/", "layout");
               }}
             >

--- a/packages/frontpage/lib/auth.ts
+++ b/packages/frontpage/lib/auth.ts
@@ -317,13 +317,17 @@ export const handlers = {
 
       invariant(handle, "Failed to get handle");
 
+      const expiresAt = new Date(
+        Date.now() + tokensResult.data.expires_in * 1000,
+      );
+
       const { lastInsertRowid } = await db.insert(schema.OauthSession).values({
         did: subjectDid,
         username: handle,
         iss: row.iss,
         accessToken: tokensResult.data.access_token,
         refreshToken: tokensResult.data.refresh_token,
-        expiresAt: new Date(Date.now() + tokensResult.data.expires_in * 1000),
+        expiresAt,
         createdAt: new Date(),
         dpopNonce,
         dpopPrivateJwk: row.dpopPrivateJwk,
@@ -339,6 +343,7 @@ export const handlers = {
         .setProtectedHeader({ alg: USER_SESSION_JWT_ALG })
         .setIssuedAt()
         .setJti(lastInsertRowid.toString())
+        .setExpirationTime(expiresAt)
         .sign(
           // TODO: This probably ought to be a different key
           await getPrivateJwk(),
@@ -357,12 +362,6 @@ export const handlers = {
     return new Response("Not found", { status: 404 });
   },
 };
-
-export function deleteAuthCookie(cookieStub: {
-  delete: (name: string) => void;
-}) {
-  cookieStub.delete(AUTH_COOKIE_NAME);
-}
 
 export async function signOut() {
   const session = await getSession();
@@ -386,9 +385,11 @@ export async function signOut() {
   await db
     .delete(schema.OauthSession)
     .where(eq(schema.OauthSession.sessionId, session.user.sessionId));
+
+  (await cookies()).delete(AUTH_COOKIE_NAME);
 }
 
-export const getSession = cache(async () => {
+export const getCookieJwt = cache(async () => {
   const tokenCookie = (await cookies()).get(AUTH_COOKIE_NAME);
   if (!tokenCookie || !tokenCookie.value) {
     return null;
@@ -399,6 +400,15 @@ export const getSession = cache(async () => {
     token = await jwtVerify(tokenCookie.value, await getPublicJwk());
   } catch (e) {
     console.error("Failed to verify token", e);
+    return null;
+  }
+
+  return token;
+});
+
+export const getSession = cache(async () => {
+  const token = await getCookieJwt();
+  if (!token) {
     return null;
   }
 

--- a/packages/frontpage/lib/auth.ts
+++ b/packages/frontpage/lib/auth.ts
@@ -366,7 +366,8 @@ export const handlers = {
 export async function signOut() {
   const session = await getSession();
   if (!session) {
-    throw new Error("Not authenticated");
+    console.warn("No session to sign out of");
+    return;
   }
   const authServer = await processDiscoveryResponse(
     new URL(session.user.iss),

--- a/packages/frontpage/middleware.ts
+++ b/packages/frontpage/middleware.ts
@@ -101,7 +101,7 @@ export async function middleware(request: NextRequest) {
 
     if ("error" in result) {
       // Logout and show error
-      console.log("session corrupt, logging out", result);
+      console.error("session corrupt, logging out", result);
       await signOut();
       const response = NextResponse.redirect(
         new URL("/login", request.url),


### PR DESCRIPTION
Undos revert of #252 that had an error in (see PR comment)