### PR TITLE
Use custom "token_exp" claim instead of exp for checking if access token has expired

### DIFF
--- a/packages/frontpage/middleware.ts
+++ b/packages/frontpage/middleware.ts
@@ -105,10 +105,10 @@ export async function middleware(request: NextRequest) {
       // Logout and show error
       console.error("session corrupt, logging out", result);
       await signOut();
-      const response = NextResponse.redirect(
-        new URL("/login", request.url),
-        NextResponse.next(),
-      );
+      const response = NextResponse.redirect(new URL("/login", request.url), {
+        status: 307,
+        headers: NextResponse.next().headers,
+      });
       return response;
     }
 


### PR DESCRIPTION
exp doesn't work here because we won't be able to decode the token and try to refresh it after it's expired