### PR TITLE
Workaround Vercel issue with unicode redirect by encoding it ourselves instead of relying on Next.js to do it for us

### DIFF
--- a/packages/atproto-browser/lib/navigation.test.ts
+++ b/packages/atproto-browser/lib/navigation.test.ts
@@ -26,9 +26,9 @@ const PATH_SUFFIXES = [
   "/collection/rkey",
 ];
 
-const makeValidCases = (authority: string) =>
+const makeValidCases = (authority: string, expectedAuthority?: string) =>
   PATH_SUFFIXES.flatMap((suffix) => {
-    const result = `/at/${authority}${suffix}`;
+    const result = `/at/${expectedAuthority ?? authority}${suffix}`;
     return [
       [`${authority}${suffix}`, result],
       [`at://${authority}${suffix}`, result],
@@ -39,11 +39,12 @@ const VALID_CASES = [
   ...makeValidCases("example.com"),
   ...makeValidCases("did:plc:hello"),
   ...makeValidCases("did:web:hello"),
-  // Unicode should be preserved, we handle punycode transformation within the fetch of the page not on navigation
-  ...makeValidCases("mañana.com"),
+  // Unicode should be uri encode but preserved, we handle punycode transformation within the fetch of the page not on navigation
+  ...makeValidCases("mañana.com", "ma%C3%B1ana.com"),
+  ...makeValidCases("ma%C3%B1ana.com"),
 
   ["@example.com", "/at/example.com"],
-  ["@mañana.com", "/at/mañana.com"],
+  ["@mañana.com", "/at/ma%C3%B1ana.com"],
 
   // Not sure about this case. Are bare hosts supported in the spec? For now we allow it to error out at a later stage
   ["host", "/at/host"],

--- a/packages/atproto-browser/lib/navigation.ts
+++ b/packages/atproto-browser/lib/navigation.ts
@@ -19,9 +19,11 @@ export async function navigateAtUri(input: string) {
 
   if (handle) {
     redirect(
-      getAtUriPath({
-        host: handle,
-      }),
+      encodeURI(
+        getAtUriPath({
+          host: handle,
+        }),
+      ),
     );
   } else if (sanitizedInput.startsWith("@")) {
     return {
@@ -41,7 +43,7 @@ export async function navigateAtUri(input: string) {
     return result;
   }
 
-  redirect(getAtUriPath(result.uri));
+  redirect(encodeURI(getAtUriPath(result.uri)));
 }
 
 /**


### PR DESCRIPTION
Workaround for https://github.com/vercel/next.js/issues/80210

> [!IMPORTANT]
> This might break (double encoding) if the next.js/vercel bug is fixed