### PR TITLE
Fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tangled.yml
+++ b/.github/workflows/tangled.yml
@@ -1,4 +1,6 @@
 name: sync-tangled
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/likeandscribe/frontpage/security/code-scanning/16](https://github.com/likeandscribe/frontpage/security/code-scanning/16)

To fix the issue, add a `permissions` block to the workflow or specifically to the job. This block should be placed at the top-level of the workflow file (after the `name:` or `on:` sections, before `jobs:`), or as a property of the `sync` job. Since the workflow appears to only read from the repository and uses SSH for push (not GITHUB_TOKEN), it only needs minimal privileges, so `contents: read` is appropriate. No further privilege is needed for this job.  
**File to edit:** `.github/workflows/tangled.yml`  
**Lines to change:** Add the line `permissions: contents: read` after the workflow name (after line 1 or after `on:` block).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
