### PR TITLE
Explicitly ensure did:plc

### DIFF
--- a/packages/frontpage/lib/data/atproto/did.ts
+++ b/packages/frontpage/lib/data/atproto/did.ts
@@ -5,7 +5,8 @@ type Brand<K, T> = K & { __brand: T };
 export type DID = Brand<string, "DID">;
 
 export function isDid(s: string): s is DID {
-  return s.startsWith("did:");
+  // We don't support did:web yet
+  return s.startsWith("did:plc:");
 }
 
 export const didSchema = z.string().refine((s) => isDid(s), {


### PR DESCRIPTION
This fixes links like https://frontpage.fyi/profile/ducky.ws. Frontpage links containing handles that resolve to did:webs (or literal did:webs) now return 404 instead of throwing an error.

We don't support did:web but up until now this was only enforced on login, not anywhere else.