### PR TITLE
getFeedSkeleton should only return local feeds

### DIFF
--- a/packages/frontpage/app/(app)/feed/[slug]/page.tsx
+++ b/packages/frontpage/app/(app)/feed/[slug]/page.tsx
@@ -6,10 +6,10 @@ import { FeedSwitcherLayout } from "../../_components/feed-switcher";
 import {
   FEED_REGISTRY,
   DEFAULT_FEED_SLUG,
-  isFeedSlug,
   FEED_URIS,
 } from "@/lib/feed-constants";
 import type { Metadata } from "next";
+import { isFeedSlug } from "@/lib/data/feed-resolver";
 
 export async function generateMetadata(
   props: PageProps<"/feed/[slug]">,

--- a/packages/frontpage/app/(app)/feed/page.tsx
+++ b/packages/frontpage/app/(app)/feed/page.tsx
@@ -1,0 +1,21 @@
+import { getFeed } from "@/lib/data/feed-resolver";
+import { AtUri } from "@atproto/syntax";
+import { redirect } from "next/navigation";
+
+export default async function FeedPage({ searchParams }: PageProps<"/feed">) {
+  let uriParam = (await searchParams).uri;
+  uriParam = Array.isArray(uriParam) ? uriParam[0] : uriParam;
+  if (!uriParam) {
+    redirect("/feed/hot");
+  }
+  let uri;
+  try {
+    uri = new AtUri(uriParam);
+  } catch (_) {
+    return <div className="p-4">Invalid URI</div>;
+  }
+
+  const posts = await getFeed(uri);
+
+  return <pre>{JSON.stringify(posts, null, 2)}</pre>;
+}

--- a/packages/frontpage/app/xrpc/fyi.frontpage.feed.getFeedSkeleton/route.ts
+++ b/packages/frontpage/app/xrpc/fyi.frontpage.feed.getFeedSkeleton/route.ts
@@ -1,12 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { verifyJwt } from "@atproto/xrpc-server";
-import { after } from "next/server";
-import { getDidDoc, parseDid } from "@/lib/data/atproto/did";
-import { invariant } from "@/lib/utils";
-import { nsids } from "@/lib/data/atproto/repo";
-import { getFeedSkeleton } from "@/lib/data/feed-resolver";
-import { publicConfig } from "@/lib/config/public-config";
 import { AtUri } from "@atproto/syntax";
+import { parseLocalFeed } from "@/lib/data/feed-resolver";
+import { getLocalFeedSkeleton } from "@/lib/data/db/feed-skeleton";
 
 const DEFAULT_SKELETON_LIMIT = 50;
 const MIN_SKELETON_LIMIT = 1;
@@ -14,31 +9,8 @@ const MAX_SKELETON_LIMIT = 100;
 const SKELETON_CACHE_MAX_AGE_SECONDS = 30;
 const SKELETON_SWR_SECONDS = 60;
 
-const BEARER_PREFIX = "Bearer ";
-
 function xrpcError(name: string, message: string, status: number) {
   return NextResponse.json({ error: name, message }, { status });
-}
-
-async function getSigningKey(
-  iss: string,
-  forceRefresh: boolean,
-): Promise<string> {
-  const issuerDid = parseDid(iss);
-  invariant(issuerDid, `Invalid DID in JWT issuer: ${iss}`);
-
-  // verifyJwt compares the cached vs fresh key to detect rotation.
-  // React.cache dedupes within a request, so we must bypass it on retry.
-  const didDoc = await getDidDoc(issuerDid, forceRefresh);
-  const verificationMethod = didDoc.verificationMethod?.find(
-    (method) => method.id === `${iss}#atproto`,
-  );
-  invariant(verificationMethod, `No atproto verification method for ${iss}`);
-  invariant(
-    verificationMethod.publicKeyMultibase,
-    `Verification method for ${iss} does not contain publicKeyMultibase`,
-  );
-  return verificationMethod.publicKeyMultibase;
 }
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -73,68 +45,15 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  // Optional JWT verification — auth not required for public feeds
-  let requesterDid: string | undefined;
-  const authHeader = request.headers.get("authorization");
-  if (authHeader?.startsWith(BEARER_PREFIX)) {
-    try {
-      const jwt = authHeader.slice(BEARER_PREFIX.length);
-      const payload = await verifyJwt(
-        jwt,
-        publicConfig.NEXT_PUBLIC_FEED_SERVICE_DID,
-        nsids.FyiFrontpageFeedGetFeedSkeleton,
-        getSigningKey,
-      );
-      requesterDid = payload.iss;
-    } catch (err) {
-      if (
-        err instanceof Error &&
-        (err.message.includes("fetch") ||
-          err.message.includes("resolve") ||
-          err.message.includes("timeout"))
-      ) {
-        console.error("JWT key resolution failed:", err);
-        return xrpcError(
-          "InternalServerError",
-          "Unable to verify authentication",
-          500,
-        );
-      }
-      return NextResponse.json(
-        { error: "AuthRequired", message: "Invalid or expired token" },
-        {
-          status: 401,
-          headers: { "WWW-Authenticate": 'Bearer realm="frontpage.fyi"' },
-        },
-      );
-    }
+  const localFeed = parseLocalFeed(feed);
+
+  if (!localFeed) {
+    return xrpcError("UnknownFeed", "Feed not found", 404);
   }
 
-  const result = await getFeedSkeleton(feed, cursor, limit);
-  if (!result.ok) {
-    const { error } = result;
-    switch (error.code) {
-      case "InvalidCollection":
-      case "UnknownFeed":
-        return xrpcError("UnknownFeed", error.message, 400);
-      case "ExternalError":
-      case "InvalidResponse":
-        return xrpcError("InternalServerError", error.message, 500);
-      default: {
-        const _exhaustive: never = error;
-        return xrpcError("InternalServerError", "Unexpected error", 500);
-      }
-    }
-  }
+  const skeleton = await getLocalFeedSkeleton(localFeed.slug, limit, cursor);
 
-  // Non-blocking logging
-  after(() => {
-    console.log(
-      `getFeedSkeleton: feed=${feed.toString()} limit=${limit} cursor=${cursor ?? "none"} results=${result.data.feed.length} requester=${requesterDid ?? "anonymous"}`,
-    );
-  });
-
-  return NextResponse.json(result.data, {
+  return NextResponse.json(skeleton, {
     headers: {
       "Cache-Control": `public, max-age=${SKELETON_CACHE_MAX_AGE_SECONDS}, stale-while-revalidate=${SKELETON_SWR_SECONDS}`,
       Vary: "Authorization",

--- a/packages/frontpage/lib/data/db/feed-skeleton.ts
+++ b/packages/frontpage/lib/data/db/feed-skeleton.ts
@@ -8,8 +8,6 @@ import { type FeedSlug } from "@/lib/feed-constants";
 import { exhaustiveCheck, invariant } from "@/lib/utils";
 import { type FyiFrontpageFeedGetFeedSkeleton } from "@repo/frontpage-atproto-client";
 
-export type SkeletonResult = FyiFrontpageFeedGetFeedSkeleton.OutputSchema;
-
 function buildAtUri(
   authorDid: string,
   collection: string,
@@ -66,10 +64,12 @@ function toSkeletonResult<
   rows: TRow[],
   limit: number,
   serializeCursorValue: (row: TRow) => string,
-): SkeletonResult {
-  const feed: SkeletonResult["feed"] = rows.map((row) => ({
-    post: buildAtUri(row.authorDid, row.collection, row.rkey),
-  }));
+): FyiFrontpageFeedGetFeedSkeleton.OutputSchema {
+  const feed: FyiFrontpageFeedGetFeedSkeleton.OutputSchema["feed"] = rows.map(
+    (row) => ({
+      post: buildAtUri(row.authorDid, row.collection, row.rkey),
+    }),
+  );
 
   // Only return a cursor if we got a full page — fewer rows means we're at the end.
   // Note: if the total post count is an exact multiple of limit, the last full page
@@ -91,7 +91,7 @@ function toSkeletonResult<
 function getHotSkeleton(
   limit: number,
   cursor: string | undefined,
-): Promise<SkeletonResult> {
+): Promise<FyiFrontpageFeedGetFeedSkeleton.OutputSchema> {
   const parsed = parseCompoundCursor(cursor);
 
   let cursorFilter: SQL | undefined;
@@ -124,7 +124,7 @@ function getHotSkeleton(
 function getNewSkeleton(
   limit: number,
   cursor: string | undefined,
-): Promise<SkeletonResult> {
+): Promise<FyiFrontpageFeedGetFeedSkeleton.OutputSchema> {
   const parsed = parseCompoundCursor(cursor);
 
   let cursorFilter: SQL | undefined;
@@ -158,7 +158,7 @@ function getNewSkeleton(
 function getTopSkeleton(
   limit: number,
   cursor: string | undefined,
-): Promise<SkeletonResult> {
+): Promise<FyiFrontpageFeedGetFeedSkeleton.OutputSchema> {
   const parsed = parseCompoundCursor(cursor);
 
   let cursorFilter: SQL | undefined;
@@ -193,12 +193,12 @@ function getTopSkeleton(
     );
 }
 
-export function getSkeletonByAlgorithm(
-  algorithm: FeedSlug,
+export function getLocalFeedSkeleton(
+  slug: FeedSlug,
   limit: number,
   cursor: string | undefined,
-): Promise<SkeletonResult> {
-  switch (algorithm) {
+): Promise<FyiFrontpageFeedGetFeedSkeleton.OutputSchema> {
+  switch (slug) {
     case "hot":
       return getHotSkeleton(limit, cursor);
     case "new":
@@ -206,6 +206,6 @@ export function getSkeletonByAlgorithm(
     case "top":
       return getTopSkeleton(limit, cursor);
     default:
-      exhaustiveCheck(algorithm);
+      exhaustiveCheck(slug);
   }
 }

--- a/packages/frontpage/lib/data/feed-resolver.ts
+++ b/packages/frontpage/lib/data/feed-resolver.ts
@@ -1,11 +1,13 @@
 import "server-only";
 
 import type { AtUri } from "@atproto/syntax";
-import { getDidDoc, parseDid, type DID } from "@/lib/data/atproto/did";
 import {
-  getSkeletonByAlgorithm,
-  type SkeletonResult,
-} from "@/lib/data/db/feed-skeleton";
+  getDidDoc,
+  getPdsUrl,
+  parseDid,
+  type DID,
+} from "@/lib/data/atproto/did";
+import { getLocalFeedSkeleton } from "@/lib/data/db/feed-skeleton";
 import { hydratePosts, type HydratedPost } from "@/lib/data/db/post";
 import { assertPublicHostname } from "@/lib/data/ssrf";
 import { invariant } from "@/lib/utils";
@@ -14,9 +16,11 @@ import {
   type FyiFrontpageFeedGetFeedSkeleton,
 } from "@repo/frontpage-atproto-client";
 import { lexicons } from "@repo/frontpage-atproto-client/lexicons";
-import { isFeedSlug } from "@/lib/feed-constants";
-import { nsids } from "@/lib/data/atproto/repo";
+import { FEED_REGISTRY, type FeedSlug } from "@/lib/feed-constants";
+import { getAtprotoClient, nsids } from "@/lib/data/atproto/repo";
 import { publicConfig } from "../config/public-config";
+import { getDidFromHandleOrDid } from "./atproto/identity";
+import { FRONTPAGE_ATPROTO_HANDLE } from "../constants";
 
 export type FeedError =
   | { code: "InvalidCollection"; message: string }
@@ -25,7 +29,7 @@ export type FeedError =
   | { code: "InvalidResponse"; message: string };
 
 export type FeedSkeletonResult =
-  | { ok: true; data: SkeletonResult }
+  | { ok: true; data: FyiFrontpageFeedGetFeedSkeleton.OutputSchema }
   | { ok: false; error: FeedError };
 
 export type FeedResult =
@@ -48,7 +52,7 @@ export async function getFeed(
   return { ok: true, posts, cursor: skeletonResult.data.cursor };
 }
 
-export async function getFeedSkeleton(
+async function getFeedSkeleton(
   feedUri: AtUri,
   cursor?: string,
   limit = 20,
@@ -63,31 +67,43 @@ export async function getFeedSkeleton(
     };
   }
 
-  if (!isFeedSlug(feedUri.rkey)) {
-    if (isLocalFeed(feedUri)) {
-      return {
-        ok: false,
-        error: {
-          code: "UnknownFeed",
-          message: `Unknown feed: ${feedUri.rkey}`,
-        },
-      };
-    }
-  }
+  const localFeed = parseLocalFeed(feedUri);
 
-  if (isLocalFeed(feedUri) && isFeedSlug(feedUri.rkey)) {
-    const skeleton = await getSkeletonByAlgorithm(feedUri.rkey, limit, cursor);
+  if (localFeed) {
+    const skeleton = await getLocalFeedSkeleton(localFeed.slug, limit, cursor);
     return { ok: true, data: skeleton };
   }
 
   return getExternalSkeleton(feedUri, cursor, limit);
 }
 
-function isLocalFeed(feedUri: AtUri): boolean {
-  return (
-    feedUri.host === publicConfig.NEXT_PUBLIC_FRONTPAGE_DID &&
-    feedUri.collection === nsids.FyiFrontpageFeedGenerator
-  );
+export function parseLocalFeed(feedUri: AtUri): null | {
+  host: DID | string;
+  slug: FeedSlug;
+} {
+  if (
+    feedUri.host !== publicConfig.NEXT_PUBLIC_FRONTPAGE_DID &&
+    feedUri.host !== FRONTPAGE_ATPROTO_HANDLE
+  ) {
+    return null;
+  }
+
+  if (feedUri.collection !== nsids.FyiFrontpageFeedGenerator) {
+    return null;
+  }
+
+  if (!isFeedSlug(feedUri.rkey)) {
+    return null;
+  }
+
+  return {
+    host: feedUri.host,
+    slug: feedUri.rkey,
+  };
+}
+
+export function isFeedSlug(s: string): s is FeedSlug {
+  return FEED_REGISTRY.some((f) => f.slug === s);
 }
 
 async function getExternalSkeleton(
@@ -151,8 +167,14 @@ async function getExternalSkeleton(
 }
 
 async function fetchGeneratorRecord(feedUri: AtUri): Promise<{ did: string }> {
-  const { getAtprotoClient } = await import("@/lib/data/atproto/repo");
-  const client = getAtprotoClient();
+  const generatorDid = await getDidFromHandleOrDid(feedUri.host);
+  invariant(generatorDid, `Could not resolve DID for ${feedUri.host}`);
+  const generatorPdsUrl = await getPdsUrl(generatorDid);
+  invariant(
+    generatorPdsUrl,
+    `Could not resolve PDS URL for DID ${generatorDid}`,
+  );
+  const client = getAtprotoClient(generatorPdsUrl);
 
   const result = await client.com.atproto.repo.getRecord({
     repo: feedUri.host,
@@ -163,15 +185,13 @@ async function fetchGeneratorRecord(feedUri: AtUri): Promise<{ did: string }> {
   const validated = FyiFrontpageFeedGenerator.validateRecord(result.data.value);
   invariant(validated.success, "Invalid generator record");
 
-  return { did: validated.value.did };
+  return validated.value;
 }
 
 async function resolveServiceEndpoint(did: DID): Promise<string> {
   const didDoc = await getDidDoc(did);
   const service = didDoc.service?.find(
-    (serviceEntry) =>
-      serviceEntry.type === "FrontpageFeedGenerator" ||
-      serviceEntry.type === "BskyFeedGenerator",
+    (serviceEntry) => serviceEntry.type === "FrontpageFeedGenerator",
   );
 
   invariant(

--- a/packages/frontpage/lib/data/feed-resolver.ts
+++ b/packages/frontpage/lib/data/feed-resolver.ts
@@ -167,14 +167,7 @@ async function getExternalSkeleton(
 }
 
 async function fetchGeneratorRecord(feedUri: AtUri): Promise<{ did: string }> {
-  const generatorDid = await getDidFromHandleOrDid(feedUri.host);
-  invariant(generatorDid, `Could not resolve DID for ${feedUri.host}`);
-  const generatorPdsUrl = await getPdsUrl(generatorDid);
-  invariant(
-    generatorPdsUrl,
-    `Could not resolve PDS URL for DID ${generatorDid}`,
-  );
-  const client = getAtprotoClient(generatorPdsUrl);
+  const client = getAtprotoClient();
 
   const result = await client.com.atproto.repo.getRecord({
     repo: feedUri.host,
@@ -185,13 +178,15 @@ async function fetchGeneratorRecord(feedUri: AtUri): Promise<{ did: string }> {
   const validated = FyiFrontpageFeedGenerator.validateRecord(result.data.value);
   invariant(validated.success, "Invalid generator record");
 
-  return validated.value;
+  return { did: validated.value.did };
 }
 
 async function resolveServiceEndpoint(did: DID): Promise<string> {
   const didDoc = await getDidDoc(did);
   const service = didDoc.service?.find(
-    (serviceEntry) => serviceEntry.type === "FrontpageFeedGenerator",
+    (serviceEntry) =>
+      serviceEntry.type === "FrontpageFeedGenerator" ||
+      serviceEntry.type === "BskyFeedGenerator",
   );
 
   invariant(

--- a/packages/frontpage/lib/data/feed-resolver.ts
+++ b/packages/frontpage/lib/data/feed-resolver.ts
@@ -1,12 +1,7 @@
 import "server-only";
 
 import type { AtUri } from "@atproto/syntax";
-import {
-  getDidDoc,
-  getPdsUrl,
-  parseDid,
-  type DID,
-} from "@/lib/data/atproto/did";
+import { getDidDoc, parseDid, type DID } from "@/lib/data/atproto/did";
 import { getLocalFeedSkeleton } from "@/lib/data/db/feed-skeleton";
 import { hydratePosts, type HydratedPost } from "@/lib/data/db/post";
 import { assertPublicHostname } from "@/lib/data/ssrf";
@@ -19,7 +14,6 @@ import { lexicons } from "@repo/frontpage-atproto-client/lexicons";
 import { FEED_REGISTRY, type FeedSlug } from "@/lib/feed-constants";
 import { getAtprotoClient, nsids } from "@/lib/data/atproto/repo";
 import { publicConfig } from "../config/public-config";
-import { getDidFromHandleOrDid } from "./atproto/identity";
 import { FRONTPAGE_ATPROTO_HANDLE } from "../constants";
 
 export type FeedError =

--- a/packages/frontpage/lib/feed-constants.ts
+++ b/packages/frontpage/lib/feed-constants.ts
@@ -39,10 +39,6 @@ export type FeedSlug = (typeof FEED_REGISTRY)[number]["slug"];
 
 export const DEFAULT_FEED_SLUG: FeedSlug = "hot";
 
-export function isFeedSlug(s: string): s is FeedSlug {
-  return FEED_REGISTRY.some((f) => f.slug === s);
-}
-
 function feedUri(slug: string) {
   return new AtUri(
     `at://${publicConfig.NEXT_PUBLIC_FRONTPAGE_DID}/${nsids.FyiFrontpageFeedGenerator}/${slug}`,

--- a/packages/frontpage/package.json
+++ b/packages/frontpage/package.json
@@ -25,7 +25,6 @@
     "@atproto/common-web": "^0.3.2",
     "@atproto/oauth-types": "^0.1.5",
     "@atproto/syntax": "catalog:",
-    "@atproto/xrpc-server": "catalog:",
     "@flags-sdk/vercel": "^1.2.1",
     "@libsql/client": "^0.15.10",
     "@markdoc/markdoc": "^0.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,6 @@ catalogs:
     '@atproto/syntax':
       specifier: ^0.4.2
       version: 0.4.2
-    '@atproto/xrpc-server':
-      specifier: ^0.10.18
-      version: 0.10.18
     '@next/env':
       specifier: ^16.2.0
       version: 16.2.2
@@ -258,9 +255,6 @@ importers:
       '@atproto/syntax':
         specifier: 'catalog:'
         version: 0.4.2
-      '@atproto/xrpc-server':
-        specifier: 'catalog:'
-        version: 0.10.18(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       '@flags-sdk/vercel':
         specifier: ^1.2.1
         version: 1.2.1(flags@4.0.5(@opentelemetry/api@1.9.0)(next@16.2.2(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(next@16.2.2(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
@@ -563,17 +557,11 @@ packages:
     engines: {node: '>=18.7.0'}
     hasBin: true
 
-  '@atproto/lex-client@0.0.18':
-    resolution: {integrity: sha512-dCnlG9nxNY6ZkaNggSlOPhb9NqDt/H1nm16ZZhe81G2iV10Niq44OcxZdVtZVjszElW3+V9ZfsK04B0f3Rid0Q==}
-
   '@atproto/lex-data@0.0.14':
     resolution: {integrity: sha512-53DUa9664SS76nGAMYopWsO10OH0AAdf7P/HSKB6Wzx3iqe6lk/K61QZnKxOG1LreYl5CfvIJU6eNf4txI6GlQ==}
 
   '@atproto/lex-json@0.0.14':
     resolution: {integrity: sha512-6lPkDKqe7teEu4WrN5q7400cvZKgYS3uwUMvzG3F9XkgVYhOwSDCtouV/nSLBbpvo3l9OP0kiigtclcNcyekww==}
-
-  '@atproto/lex-schema@0.0.17':
-    resolution: {integrity: sha512-WLeGIRgLQEhpTd5jpaplvKEtITS7PCygWHmCD645q0MFzQ+C2AM8KWwUqvhVHOgHNNRPZrYfMgnsq6gYmu2tEQ==}
 
   '@atproto/lexicon@0.4.14':
     resolution: {integrity: sha512-jiKpmH1QER3Gvc7JVY5brwrfo+etFoe57tKPQX/SmPwjvUsFnJAow5xLIryuBaJgFAhnTZViXKs41t//pahGHQ==}
@@ -593,14 +581,6 @@ packages:
 
   '@atproto/syntax@0.5.2':
     resolution: {integrity: sha512-W41szOnkppoHr0iCUrzL8gy3OD6qmDyp1UvUgmTx2oFQfgbudpz51T/gznesiCcqiUT5obfHdx4PJ+WdlEOE7Q==}
-
-  '@atproto/ws-client@0.0.4':
-    resolution: {integrity: sha512-dox1XIymuC7/ZRhUqKezIGgooZS45C6vHCfu0PnWjfvsLCK2kAlnvX4IBkA/WpcoijDhQ9ejChnFbo/sLmgvAg==}
-    engines: {node: '>=18.7.0'}
-
-  '@atproto/xrpc-server@0.10.18':
-    resolution: {integrity: sha512-S3QA+7yRF5qlHaVdRA8xF3qqny1OGP4lqePIW7GtjdTmAg8Y0Q0NWUUNPHR+w6qdB4fOa1OVQiNtzxq++e0EQw==}
-    engines: {node: '>=18.7.0'}
 
   '@atproto/xrpc@0.6.12':
     resolution: {integrity: sha512-Ut3iISNLujlmY9Gu8sNU+SPDJDvqlVzWddU8qUr0Yae5oD4SguaUFjjhireMGhQ3M5E0KljQgDbTmnBo1kIZ3w==}
@@ -2826,10 +2806,6 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
-  accepts@1.3.8:
-    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
-    engines: {node: '>= 0.6'}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2887,9 +2863,6 @@ packages:
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
-
-  array-flatten@1.1.1:
-    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
@@ -2970,10 +2943,6 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  body-parser@1.20.4:
-    resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -3001,10 +2970,6 @@ packages:
   bufferutil@4.0.8:
     resolution: {integrity: sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==}
     engines: {node: '>=6.14.2'}
-
-  bytes@3.1.2:
-    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
-    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -3079,26 +3044,11 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  content-disposition@0.5.4:
-    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
-    engines: {node: '>= 0.6'}
-
-  content-type@1.0.5:
-    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
-    engines: {node: '>= 0.6'}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie-signature@1.0.7:
-    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
-
   cookie@0.4.0:
     resolution: {integrity: sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==}
-    engines: {node: '>= 0.6'}
-
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   cross-spawn@7.0.6:
@@ -3150,14 +3100,6 @@ packages:
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
-  debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -3193,17 +3135,9 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
-  depd@2.0.0:
-    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
-    engines: {node: '>= 0.8'}
-
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
-
-  destroy@1.2.0:
-    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
@@ -3340,18 +3274,11 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-
   electron-to-chromium@1.5.234:
     resolution: {integrity: sha512-RXfEp2x+VRYn8jbKfQlRImzoJU01kyDvVPBmG39eU2iuRVhuS6vQNocB8J0/8GrIMLnPzgz4eW6WiRnJkTuNWg==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-
-  encodeurl@2.0.0:
-    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
-    engines: {node: '>= 0.8'}
 
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
@@ -3600,10 +3527,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  etag@1.8.1:
-    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
-    engines: {node: '>= 0.6'}
-
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -3622,10 +3545,6 @@ packages:
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
-
-  express@4.22.1:
-    resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
-    engines: {node: '>= 0.10.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -3674,10 +3593,6 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
-
-  finalhandler@1.3.2:
-    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
-    engines: {node: '>= 0.8'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -3730,14 +3645,6 @@ packages:
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
-
-  forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
-
-  fresh@0.5.2:
-    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
-    engines: {node: '>= 0.6'}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3866,10 +3773,6 @@ packages:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
-  http-errors@2.0.1:
-    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
-    engines: {node: '>= 0.8'}
-
   http-link-header@1.1.3:
     resolution: {integrity: sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==}
     engines: {node: '>=6.0.0'}
@@ -3889,10 +3792,6 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-
-  iconv-lite@0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -3917,16 +3816,9 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
-  inherits@2.0.4:
-    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
-
-  ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
 
   ipaddr.js@2.2.0:
     resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
@@ -4242,23 +4134,12 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  media-typer@0.3.0:
-    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
-    engines: {node: '>= 0.6'}
-
-  merge-descriptors@1.0.3:
-    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
-
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
-
-  methods@1.1.2:
-    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
-    engines: {node: '>= 0.6'}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -4276,11 +4157,6 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  mime@1.6.0:
-    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -4294,9 +4170,6 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -4319,10 +4192,6 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  negotiator@0.6.3:
-    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
-    engines: {node: '>= 0.6'}
 
   negotiator@0.6.4:
     resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
@@ -4427,10 +4296,6 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
-  on-finished@2.4.1:
-    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
-
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
@@ -4461,10 +4326,6 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
-  parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
-
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -4478,9 +4339,6 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-
-  path-to-regexp@0.1.13:
-    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
   path-to-regexp@6.2.1:
     resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
@@ -4551,20 +4409,12 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
-  proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
-
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
-    engines: {node: '>=0.6'}
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -4591,13 +4441,6 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-
-  rate-limiter-flexible@2.4.2:
-    resolution: {integrity: sha512-rMATGGOdO1suFyf/mI5LYhts71g1sbdhmd6YvdiXO2gJnd42Tt6QS4JUKJKSWVVkMtBacm6l40FR7Trjo6Iruw==}
-
-  raw-body@2.5.3:
-    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
-    engines: {node: '>= 0.8'}
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -4765,14 +4608,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  send@0.19.2:
-    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
-    engines: {node: '>= 0.8.0'}
-
-  serve-static@1.16.3:
-    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
-    engines: {node: '>= 0.8.0'}
-
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
@@ -4787,9 +4622,6 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
-
-  setprototypeof@1.2.0:
-    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
@@ -4858,10 +4690,6 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-
-  statuses@2.0.2:
-    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
-    engines: {node: '>= 0.8'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -4981,10 +4809,6 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  toidentifier@1.0.1:
-    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
-    engines: {node: '>=0.6'}
-
   tough-cookie@4.1.4:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
@@ -5064,10 +4888,6 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-is@1.6.18:
-    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
-    engines: {node: '>= 0.6'}
-
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -5112,10 +4932,6 @@ packages:
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
-
-  unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
@@ -5164,16 +4980,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  utils-merge@1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
-    engines: {node: '>= 0.4.0'}
-
   varint@6.0.0:
     resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
-
-  vary@1.1.2:
-    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
-    engines: {node: '>= 0.8'}
 
   vite-tsconfig-paths@5.1.4:
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
@@ -5463,13 +5271,6 @@ snapshots:
       yesno: 0.4.0
       zod: 3.25.76
 
-  '@atproto/lex-client@0.0.18':
-    dependencies:
-      '@atproto/lex-data': 0.0.14
-      '@atproto/lex-json': 0.0.14
-      '@atproto/lex-schema': 0.0.17
-      tslib: 2.8.1
-
   '@atproto/lex-data@0.0.14':
     dependencies:
       multiformats: 9.9.0
@@ -5480,14 +5281,6 @@ snapshots:
   '@atproto/lex-json@0.0.14':
     dependencies:
       '@atproto/lex-data': 0.0.14
-      tslib: 2.8.1
-
-  '@atproto/lex-schema@0.0.17':
-    dependencies:
-      '@atproto/lex-data': 0.0.14
-      '@atproto/syntax': 0.5.2
-      '@standard-schema/spec': 1.1.0
-      iso-datestring-validator: 2.2.2
       tslib: 2.8.1
 
   '@atproto/lexicon@0.4.14':
@@ -5528,36 +5321,6 @@ snapshots:
   '@atproto/syntax@0.5.2':
     dependencies:
       tslib: 2.8.1
-
-  '@atproto/ws-client@0.0.4(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
-    dependencies:
-      '@atproto/common': 0.5.15
-      ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
-  '@atproto/xrpc-server@0.10.18(bufferutil@4.0.8)(utf-8-validate@6.0.3)':
-    dependencies:
-      '@atproto/common': 0.5.15
-      '@atproto/crypto': 0.4.5
-      '@atproto/lex-cbor': 0.0.15
-      '@atproto/lex-client': 0.0.18
-      '@atproto/lex-data': 0.0.14
-      '@atproto/lex-json': 0.0.14
-      '@atproto/lex-schema': 0.0.17
-      '@atproto/lexicon': 0.6.2
-      '@atproto/ws-client': 0.0.4(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      '@atproto/xrpc': 0.7.7
-      express: 4.22.1
-      http-errors: 2.0.1
-      mime-types: 2.1.35
-      rate-limiter-flexible: 2.4.2
-      ws: 8.18.3(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   '@atproto/xrpc@0.6.12':
     dependencies:
@@ -7594,11 +7357,6 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
-  accepts@1.3.8:
-    dependencies:
-      mime-types: 2.1.35
-      negotiator: 0.6.3
-
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -7652,8 +7410,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       is-array-buffer: 3.0.5
-
-  array-flatten@1.1.1: {}
 
   array-includes@3.1.9:
     dependencies:
@@ -7749,23 +7505,6 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  body-parser@1.20.4:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      http-errors: 2.0.1
-      iconv-lite: 0.4.24
-      on-finished: 2.4.1
-      qs: 6.14.2
-      raw-body: 2.5.3
-      type-is: 1.6.18
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   boolbase@1.0.0: {}
 
   brace-expansion@1.1.12:
@@ -7800,8 +7539,6 @@ snapshots:
     dependencies:
       node-gyp-build: 4.8.4
     optional: true
-
-  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -7874,19 +7611,9 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  content-disposition@0.5.4:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  content-type@1.0.5: {}
-
   convert-source-map@2.0.0: {}
 
-  cookie-signature@1.0.7: {}
-
   cookie@0.4.0: {}
-
-  cookie@0.7.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7942,10 +7669,6 @@ snapshots:
 
   date-fns@3.6.0: {}
 
-  debug@2.6.9:
-    dependencies:
-      ms: 2.0.0
-
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -7972,11 +7695,7 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  depd@2.0.0: {}
-
   dequal@2.0.3: {}
-
-  destroy@1.2.0: {}
 
   detect-libc@2.0.2: {}
 
@@ -8030,13 +7749,9 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  ee-first@1.1.1: {}
-
   electron-to-chromium@1.5.234: {}
 
   emoji-regex@9.2.2: {}
-
-  encodeurl@2.0.0: {}
 
   enhanced-resolve@5.18.4:
     dependencies:
@@ -8485,8 +8200,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  etag@1.8.1: {}
-
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
@@ -8506,42 +8219,6 @@ snapshots:
       strip-final-newline: 2.0.0
 
   expect-type@1.2.2: {}
-
-  express@4.22.1:
-    dependencies:
-      accepts: 1.3.8
-      array-flatten: 1.1.1
-      body-parser: 1.20.4
-      content-disposition: 0.5.4
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.0.7
-      debug: 2.6.9
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 1.3.2
-      fresh: 0.5.2
-      http-errors: 2.0.1
-      merge-descriptors: 1.0.3
-      methods: 1.1.2
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      path-to-regexp: 0.1.13
-      proxy-addr: 2.0.7
-      qs: 6.14.2
-      range-parser: 1.2.1
-      safe-buffer: 5.2.1
-      send: 0.19.2
-      serve-static: 1.16.3
-      setprototypeof: 1.2.0
-      statuses: 2.0.2
-      type-is: 1.6.18
-      utils-merge: 1.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
@@ -8590,18 +8267,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.3.2:
-    dependencies:
-      debug: 2.6.9
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -8641,10 +8306,6 @@ snapshots:
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
-
-  forwarded@0.2.0: {}
-
-  fresh@0.5.2: {}
 
   fsevents@2.3.3:
     optional: true
@@ -8761,14 +8422,6 @@ snapshots:
     dependencies:
       whatwg-encoding: 3.1.1
 
-  http-errors@2.0.1:
-    dependencies:
-      depd: 2.0.0
-      inherits: 2.0.4
-      setprototypeof: 1.2.0
-      statuses: 2.0.2
-      toidentifier: 1.0.1
-
   http-link-header@1.1.3: {}
 
   http-proxy-agent@7.0.2:
@@ -8795,10 +8448,6 @@ snapshots:
 
   human-signals@2.1.0: {}
 
-  iconv-lite@0.4.24:
-    dependencies:
-      safer-buffer: 2.1.2
-
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -8816,15 +8465,11 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
-  inherits@2.0.4: {}
-
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
-
-  ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.2.0: {}
 
@@ -9134,15 +8779,9 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  media-typer@0.3.0: {}
-
-  merge-descriptors@1.0.3: {}
-
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
-
-  methods@1.1.2: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -9157,8 +8796,6 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  mime@1.6.0: {}
-
   mimic-fn@2.1.0: {}
 
   minimatch@3.1.2:
@@ -9171,8 +8808,6 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  ms@2.0.0: {}
-
   ms@2.1.3: {}
 
   multiformats@13.3.7: {}
@@ -9184,8 +8819,6 @@ snapshots:
   napi-postinstall@0.3.0: {}
 
   natural-compare@1.4.0: {}
-
-  negotiator@0.6.3: {}
 
   negotiator@0.6.4: {}
 
@@ -9296,10 +8929,6 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
-  on-finished@2.4.1:
-    dependencies:
-      ee-first: 1.1.1
-
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
@@ -9337,8 +8966,6 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
-  parseurl@1.3.3: {}
-
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -9346,8 +8973,6 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
-
-  path-to-regexp@0.1.13: {}
 
   path-to-regexp@6.2.1: {}
 
@@ -9421,20 +9046,11 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
-  proxy-addr@2.0.7:
-    dependencies:
-      forwarded: 0.2.0
-      ipaddr.js: 1.9.1
-
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
 
   punycode@2.3.1: {}
-
-  qs@6.14.2:
-    dependencies:
-      side-channel: 1.1.0
 
   querystringify@2.2.0: {}
 
@@ -9506,15 +9122,6 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.13)
 
   range-parser@1.2.1: {}
-
-  rate-limiter-flexible@2.4.2: {}
-
-  raw-body@2.5.3:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.4.24
-      unpipe: 1.0.0
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:
@@ -9696,33 +9303,6 @@ snapshots:
 
   semver@7.7.3: {}
 
-  send@0.19.2:
-    dependencies:
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      fresh: 0.5.2
-      http-errors: 2.0.1
-      mime: 1.6.0
-      ms: 2.1.3
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
-  serve-static@1.16.3:
-    dependencies:
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      parseurl: 1.3.3
-      send: 0.19.2
-    transitivePeerDependencies:
-      - supports-color
-
   server-only@0.0.1: {}
 
   set-function-length@1.2.2:
@@ -9746,8 +9326,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
-
-  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -9844,8 +9422,6 @@ snapshots:
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
-
-  statuses@2.0.2: {}
 
   std-env@3.10.0: {}
 
@@ -9974,8 +9550,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  toidentifier@1.0.1: {}
-
   tough-cookie@4.1.4:
     dependencies:
       psl: 1.15.0
@@ -10047,11 +9621,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-is@1.6.18:
-    dependencies:
-      media-typer: 0.3.0
-      mime-types: 2.1.35
-
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -10114,8 +9683,6 @@ snapshots:
   unicode-segmenter@0.14.0: {}
 
   universalify@0.2.0: {}
-
-  unpipe@1.0.0: {}
 
   unrs-resolver@1.11.1:
     dependencies:
@@ -10182,11 +9749,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  utils-merge@1.0.1: {}
-
   varint@6.0.0: {}
-
-  vary@1.1.2: {}
 
   vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.2.2(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.34.1)(yaml@2.8.0)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,7 +31,6 @@ catalog:
   '@atproto/api': ^0.18.8
   '@atproto/lexicon': ^0.6.0
   '@atproto/xrpc': ^0.7.7
-  '@atproto/xrpc-server': ^0.10.18
 
 onlyBuiltDependencies:
   - '@vercel/speed-insights'


### PR DESCRIPTION
There was an implementation error in #339 that attempted to fetch arbitrary feeds via frontpage's getFeedSkeleton, but our feed server should only return feeds that we support - it's not a generic proxy.

Also as part of this PR I've removed the unused authentication implementation - our feeds don't need it and `getExternalSkeleton` doesn't currently implement auth anyway. We can add authenticated feeds in a separate PR (issue: #351).