### PR TITLE
Expand globs in eslint print script

### DIFF
--- a/apps/atproto-browser/app/at/_lib/video-embed-client.tsx
+++ b/apps/atproto-browser/app/at/_lib/video-embed-client.tsx
@@ -45,7 +45,7 @@ export function VideoEmbedClient({
       hls.detachMedia();
       hls.destroy();
     };
-  }, [source, sessionId]);
+  }, [source]);
 
   return <VideoEmbedWrapper videoRef={ref} />;
 }

--- a/apps/atproto-browser/app/at/_lib/video-embed-client.tsx
+++ b/apps/atproto-browser/app/at/_lib/video-embed-client.tsx
@@ -45,7 +45,7 @@ export function VideoEmbedClient({
       hls.detachMedia();
       hls.destroy();
     };
-  }, [source]);
+  }, [source, sessionId]);
 
   return <VideoEmbedWrapper videoRef={ref} />;
 }

--- a/packages/eslint-config/pretty-print-report.ts
+++ b/packages/eslint-config/pretty-print-report.ts
@@ -37,8 +37,22 @@ function prettyPrintReport(report: ESLint.LintResult[]): void {
   console.log(`\nTotal: ${totalErrors} errors, ${totalWarnings} warnings`);
 }
 
+console.log(`Expanding globs:\n ${process.argv.slice(2).join("\n")}`);
+
+const paths = (
+  await Promise.all(
+    process.argv
+      .slice(2)
+      .map(async (glob) => Array.fromAsync(fs.glob(glob.trim()))),
+  )
+).flat();
+
+console.log(
+  `Found ${paths.length} report files to process. Paths:\n${paths.join("\n")}`,
+);
+
 const reports = await Promise.all(
-  process.argv.slice(2).map(async (path) => ({
+  paths.map(async (path) => ({
     contents: await readReportFile(path),
     filePath: path,
   })),

--- a/packages/eslint-config/tsconfig.json
+++ b/packages/eslint-config/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "NodeNext",
     "noEmit": true,
     "strict": true,
+    "lib": ["ESNext"],
     "types": ["node"]
   }
 }


### PR DESCRIPTION
## What

Handles passing globs to the eslint pretty print script.

## Why

This allows shells without glob expansion to call the script, as well as handle the edge case in bash where globs without matches are unexpanded by default.

## Test plan

CI lint task
